### PR TITLE
Add cache invalidation system.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "babel-preset-es2015": "^6.14.0",
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-0": "^6.5.0",
+    "chokidar": "^1.6.0",
     "insert-css": "^1.0.0",
     "marked": "^0.3.6",
     "react": "^15.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1250,7 +1250,7 @@ chalk@1.1.1:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chokidar@^1.0.0:
+chokidar@^1.0.0, chokidar@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.6.0.tgz#90c32ad4802901d7713de532dc284e96a63ad058"
   dependencies:


### PR DESCRIPTION
Now comments won't get fetch for everytime we switch stories.
Instead it'll use the cache and invalidate if needed.
We also reload comments for every minute.
