### PR TITLE
Set the protected field to true

### DIFF
--- a/src/manager/containers/CommentsPanel/dataStore.js
+++ b/src/manager/containers/CommentsPanel/dataStore.js
@@ -167,6 +167,7 @@ export default class DataStore {
     const doc = {
       ...comment,
       ...this.currentStory,
+      sbProtected: true,
     };
 
     return this.db.getCollection('comments').set(doc);


### PR DESCRIPTION
If the sbProtected field is set when using with the
Storybook Hub Datastore, only the person who created
the document can update/delete the document.
