### PR TITLE
Add the user to the local cache when adding a comment.

### DIFF
--- a/src/manager/containers/CommentsPanel/dataStore.js
+++ b/src/manager/containers/CommentsPanel/dataStore.js
@@ -163,6 +163,10 @@ export default class DataStore {
       return Promise.resolve(null);
     }
 
+    // add user to the local cache
+    this.users[this.user.id] = this.user;
+
+    // add user to the actual collection
     return this.db.getCollection('users').set(this.user);
   }
 
@@ -184,8 +188,8 @@ export default class DataStore {
   }
 
   addComment(comment) {
-    this._addPendingComment(comment)
-      .then(() => this._addAuthorToTheDatabase())
+    this._addAuthorToTheDatabase()
+      .then(() => this._addPendingComment(comment))
       .then(() => this._addCommentToDatabase(comment))
       .then(() => this._loadUsers())
       .then(() => this._loadComments());


### PR DESCRIPTION
Now when we add the pending comment to the local cache, it can read the current user's profile.

This fixes #39 
