### PR TITLE
Add border-radius for comment form

### DIFF
--- a/src/manager/components/CommentForm/style.js
+++ b/src/manager/components/CommentForm/style.js
@@ -15,7 +15,6 @@ export default {
     display: 'flex',
     alignItems: 'center',
     borderTop: '1px solid rgb(234, 234, 234)',
-    backgroundColor: '#fafafa',
   },
   loginButton: {
     ...button,
@@ -25,6 +24,7 @@ export default {
   submitButton: {
     ...button,
     cursor: 'pointer',
+    borderRadius: '0 0 4px 0',
   },
   input: {
     flex: 1,
@@ -32,6 +32,7 @@ export default {
     height: 30,
     maxHeight: 70,
     border: 'none',
+    borderRadius: '0 0 0 4px',
     outline: 'none',
     padding: '5px 10px',
     fontSize: 13,


### PR DESCRIPTION
Add a 4px border radius at appropriate corners to make the comment
panel look consistent with Storybook UI.
